### PR TITLE
[kube-client] Bump deckhouse logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+GO=$(shell which go)
+GIT=$(shell which git)
+
+.PHONY: go-check
+go-check:
+	$(call error-if-empty,$(GO),go)
+
+.PHONY: git-check
+git-check:
+	$(call error-if-empty,$(GIT),git)
+
+.PHONY: go-module-version
+go-module-version: go-check git-check
+	@echo "go get $(shell $(GO) list ./client)@$(shell $(GIT) rev-parse HEAD)"
+
+.PHONY: test
+test: go-check
+	@$(GO) test --race --cover ./...
+
+define error-if-empty
+@if [[ -z $(1) ]]; then echo "$(2) not installed"; false; fi
+endef

--- a/client/client.go
+++ b/client/client.go
@@ -56,7 +56,7 @@ func New(opts ...Option) *Client {
 	}
 
 	if c.logger == nil {
-		c.logger = log.NewLogger(log.Options{}).Named("kubernetes-api-client").With("operator.component", "KubernetesAPIClient")
+		c.logger = log.NewLogger().Named("kubernetes-api-client").With("operator.component", "KubernetesAPIClient")
 	}
 
 	return c
@@ -151,7 +151,7 @@ func (c *Client) RestConfig() *rest.Config {
 
 func (c *Client) Init() error {
 	if c.logger == nil {
-		c.logger = log.NewLogger(log.Options{}).Named("kubernetes-api-client").With("operator.component", "KubernetesAPIClient")
+		c.logger = log.NewLogger().Named("kubernetes-api-client").With("operator.component", "KubernetesAPIClient")
 	}
 
 	var err error

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/flant/kube-client
 go 1.23.8
 
 require (
-	github.com/deckhouse/deckhouse/pkg/log v0.0.0-20241106140903-258b93b3334e
+	github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250704135428-7600b0581807
 	github.com/onsi/gomega v1.31.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/deckhouse/pkg/log v0.0.0-20241106140903-258b93b3334e h1:QUQy+5Bv7/UzhfrytiG3c5gfLGhPppepVbRpbMisVIw=
-github.com/deckhouse/deckhouse/pkg/log v0.0.0-20241106140903-258b93b3334e/go.mod h1:Mk5HRzkc5pIcDIZ2JJ6DPuuqnwhXVkb3you8M8Mg+4w=
+github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250704135428-7600b0581807 h1:0kf//0CzwRhJZBTz3yzeZtHIQumWqsCU0DR+HM5r+PA=
+github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250704135428-7600b0581807/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/klogtolog/adapter.go
+++ b/klogtolog/adapter.go
@@ -41,6 +41,10 @@ type writer struct {
 
 var klogRe = regexp.MustCompile(`^.* .*  .* (.*\d+)\] (.*)\n$`)
 
+// examples
+// {"level":"warn","msg":"Warning from klog powered lib (lib_methods.go:8)","file_and_line":"lib_methods.go:8","time":"2025-07-04T19:39:28+03:00"}
+// {"level":"info","msg":"Info from klog powered lib (lib_methods.go:12)","file_and_line":"lib_methods.go:12","time":"2025-07-04T19:39:28+03:00"}
+// {"level":"error","msg":"Error from klog powered lib (adapter_test.go:48)","file_and_line":"adapter_test.go:48", "stacktrace": ... ,"time":"2025-07-04T19:39:28+03:00"}
 func (w *writer) Write(msg []byte) (n int, err error) {
 	groups := klogRe.FindStringSubmatch(string(msg))
 

--- a/klogtolog/adapter.go
+++ b/klogtolog/adapter.go
@@ -42,6 +42,15 @@ type writer struct {
 var klogRe = regexp.MustCompile(`^.* .*  .* (.*\d+)\] (.*)\n$`)
 
 // examples
+//
+// from this
+//
+// I0704 19:13:35.888843  135000 lib_methods.go:12] Info from klog powered lib\n
+// W0704 19:13:35.888120  135000 lib_methods.go:8] Warning from klog powered lib\n
+// E0704 19:13:35.888852  135000 adapter_test.go:48] Error from klog powered lib\n
+//
+// to this
+//
 // {"level":"warn","msg":"Warning from klog powered lib (lib_methods.go:8)","file_and_line":"lib_methods.go:8","time":"2025-07-04T19:39:28+03:00"}
 // {"level":"info","msg":"Info from klog powered lib (lib_methods.go:12)","file_and_line":"lib_methods.go:12","time":"2025-07-04T19:39:28+03:00"}
 // {"level":"error","msg":"Error from klog powered lib (adapter_test.go:48)","file_and_line":"adapter_test.go:48", "stacktrace": ... ,"time":"2025-07-04T19:39:28+03:00"}

--- a/klogtolog/adapter.go
+++ b/klogtolog/adapter.go
@@ -50,9 +50,9 @@ var klogRe = regexp.MustCompile(`^.* .*  .* (.*\d+)\] (.*)\n$`)
 //
 // to this
 //
-// {"level":"warn","msg":"Warning from klog powered lib (lib_methods.go:8)","file_and_line":"lib_methods.go:8","time":"2025-07-04T19:39:28+03:00"}
-// {"level":"info","msg":"Info from klog powered lib (lib_methods.go:12)","file_and_line":"lib_methods.go:12","time":"2025-07-04T19:39:28+03:00"}
-// {"level":"error","msg":"Error from klog powered lib (adapter_test.go:48)","file_and_line":"adapter_test.go:48", "stacktrace": ... ,"time":"2025-07-04T19:39:28+03:00"}
+// {"level":"warn","msg":"Warning from klog powered lib (lib_methods.go:8)","file":"lib_methods.go:8","time":"2025-07-04T19:39:28+03:00"}
+// {"level":"info","msg":"Info from klog powered lib (lib_methods.go:12)","file":"lib_methods.go:12","time":"2025-07-04T19:39:28+03:00"}
+// {"level":"error","msg":"Error from klog powered lib (adapter_test.go:48)","file":"adapter_test.go:48", "stacktrace": ... ,"time":"2025-07-04T19:39:28+03:00"}
 func (w *writer) Write(msg []byte) (n int, err error) {
 	logger := w.logger
 
@@ -60,7 +60,7 @@ func (w *writer) Write(msg []byte) (n int, err error) {
 
 	var message string
 	if len(groups) > 2 {
-		logger = logger.With("file_and_line", groups[1])
+		logger = logger.With("file", groups[1])
 
 		message = groups[2] + " (" + groups[1] + ")"
 	} else {

--- a/klogtolog/test/adapter_test.go
+++ b/klogtolog/test/adapter_test.go
@@ -59,7 +59,8 @@ func Test_adapter_catches_klog_WarnInfoError(t *testing.T) {
 	for i, line := range lines {
 		tt := tests[i]
 
-		var record map[string]string
+		// not map[string]string because we have nested stacktrace
+		var record map[string]interface{}
 		err := json.Unmarshal([]byte(line), &record)
 		g.Expect(err).ShouldNot(HaveOccurred(), line, "log line should be a valid JSON")
 

--- a/klogtolog/test/adapter_test.go
+++ b/klogtolog/test/adapter_test.go
@@ -23,7 +23,7 @@ func Test_adapter_catches_klog_WarnInfoError(t *testing.T) {
 
 	buf := gbytes.NewBuffer()
 
-	logger := log.NewLogger(log.Options{})
+	logger := log.NewLogger()
 	logger.SetOutput(buf)
 	klogtolog.InitAdapter(false, logger)
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Bump deckhouse logger (add options pattern)
Fix test (falls because of trying to parse stacktrace array to string)

Enhance klog log handling

### Before
```
{"level":"warn","msg":"W0704 19:13:35.888120  135000 lib_methods.go:8] Warning from klog powered lib\n","time":"2025-07-04T19:39:28+03:00"}
{"level":"info","msg":"I0704 19:13:35.888843  135000 lib_methods.go:12] Info from klog powered lib\n","time":"2025-07-04T19:39:28+03:00"}
{"level":"error","msg":"E0704 19:13:35.888852  135000 adapter_test.go:48] Error from klog powered lib\n", "stacktrace": ... ,"time":"2025-07-04T19:39:28+03:00"}
```

### After
```
{"level":"warn","msg":"Warning from klog powered lib (lib_methods.go:8)","file_and_line":"lib_methods.go:8","time":"2025-07-04T19:39:28+03:00"}
{"level":"info","msg":"Info from klog powered lib (lib_methods.go:12)","file_and_line":"lib_methods.go:12","time":"2025-07-04T19:39:28+03:00"}
{"level":"error","msg":"Error from klog powered lib (adapter_test.go:48)","file_and_line":"adapter_test.go:48", "stacktrace": ... ,"time":"2025-07-04T19:39:28+03:00"}
```
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```