### PR TITLE
Add WithAcceptOnlyJSONContentType method to set AcceptContentTypes to rest config

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -93,6 +93,9 @@ type Client struct {
 	schema           *runtime.Scheme
 	restConfig       *rest.Config
 	logger           *log.Logger
+	// acceptOnlyJSONContentType
+	// use only JSON for interactions with kube-api
+	acceptOnlyJSONContentType bool
 }
 
 // ReloadDynamic creates new dynamic client with the new set of CRDs.
@@ -115,6 +118,16 @@ func (c *Client) WithContextName(name string) {
 
 func (c *Client) WithConfigPath(path string) {
 	c.configPath = path
+}
+
+func (c *Client) WithAcceptOnlyJSONContentType(e bool) {
+	c.acceptOnlyJSONContentType = e
+}
+
+func (c *Client) WithLogger(logger *log.Logger) {
+	if logger != nil {
+		c.logger = logger
+	}
 }
 
 func (c *Client) WithRateLimiterSettings(qps float32, burst int) {
@@ -217,6 +230,10 @@ func (c *Client) Init() error {
 
 	if config == nil {
 		return fmt.Errorf("failed to initialize kubernetes client: no valid configuration found")
+	}
+
+	if c.acceptOnlyJSONContentType {
+		config.AcceptContentTypes = "application/json"
 	}
 
 	c.defaultNamespace = defaultNs


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add `WithAcceptOnlyJSONContentType` method to set `AcceptContentTypes` to rest config to report API-server
to send response in JSON format.

In some products (like dhctl in deckhouse) we are logging all requests and responses to debug log file.
But API server often send response in protobuf format like this:
```
2026-02-11 18:08:57 - klog: I0211 18:08:57.877297   20161 round_trippers.go:584] Response Headers:
2026-02-11 18:08:57 - klog: I0211 18:08:57.877310   20161 round_trippers.go:587]     Audit-Id: d68d3383-dfd1-4734-93c4-39fd4b19073f
2026-02-11 18:08:57 - klog: I0211 18:08:57.877321   20161 round_trippers.go:587]     Cache-Control: no-cache, private
2026-02-11 18:08:57 - klog: I0211 18:08:57.877406   20161 round_trippers.go:587]     Content-Type: application/vnd.kubernetes.protobuf
2026-02-11 18:08:57 - klog: I0211 18:08:57.877415   20161 round_trippers.go:587]     Date: Wed, 11 Feb 2026 18:08:57 GMT
2026-02-11 18:08:57 - klog: I0211 18:08:57.877421   20161 round_trippers.go:587]     X-Kubernetes-Pf-Flowschema-Uid: cb6143bf-2e72-40ec-9530-8f45641e9905
2026-02-11 18:08:57 - klog: I0211 18:08:57.877429   20161 round_trippers.go:587]     X-Kubernetes-Pf-Prioritylevel-Uid: 6300b971-a35b-447f-90e2-f9031dc9e617
2026-02-11 18:08:57 - klog: I0211 18:08:57.887635   20161 type.go:168] "Response Body" body=<
        00000000  6b 38 73 00 0a 0c 0a 02  76 31 12 06 53 65 63 72  |k8s.....v1..Secr|
        00000010  65 74 12 ef 20 0a f2 02  0a 21 64 38 2d 70 72 6f  |et.. ....!d8-pro|
        00000020  76 69 64 65 72 2d 63 6c  75 73 74 65 72 2d 63 6f  |vider-cluster-co|
```

This log is multiline and huge. It is bad for obseravbility logs. Also it is complex to analyse response because output is formatted bytes.

Also, we added `WithLogger` method to set logger after creating Client

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```